### PR TITLE
commit() must always return a value

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -19,6 +19,9 @@
     </authors>
     
     <releases>
+        <release version="1.2.2" date="2014-08-27" min="2.4" max="2.6.x">
+            - Make sure FieldHashid_field::commit() always returns a value
+        </release>
         <release version="1.2.1" date="2014-08-27" min="2.4" max="2.5.x">
             - Version bump.
             - Added support for 'not:' in data source filtering. (Thanks @nitriques!)

--- a/fields/field.hashid_field.php
+++ b/fields/field.hashid_field.php
@@ -120,7 +120,7 @@
             $fields['length'] = max(1, (int)$this->get('length'));
             $fields['salt'] = $this->get('salt');
 
-            if(!FieldManager::saveSettings($id, $fields)) return false;
+            return FieldManager::saveSettings($id, $fields);
         }
 
         /*-------------------------------------------------------------------------


### PR DESCRIPTION
Easiest way is to return the value from FieldManager::saveSettings();

null can be interpreted as false which can lead to false negative.

I've also created a new version for faster merge and publish.

Thanks Nathan!