### PR TITLE
Fix fatal error when saving hashid field #37

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -107,7 +107,7 @@ class extension_Hashid_field extends Extension
             }
         }
 
-        if (version_compare($previousVersion, '2.0.0', '<=')) {
+        if (version_compare($previousVersion, '2.0.1', '<')) {
             Symphony::Database()->query(
                 "ALTER TABLE `tbl_fields_hashid_field`
                     DROP COLUMN `size`;"

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -69,7 +69,6 @@ class extension_Hashid_field extends Extension
                 "CREATE TABLE IF NOT EXISTS `tbl_fields_hashid_field` (
                     `id` int(11) unsigned NOT NULL auto_increment,
                     `field_id` int(11) unsigned NOT NULL,
-                    `size` int(3) unsigned NOT NULL,
                     `salt` VARCHAR(255) NOT NULL,
                     `length` int(2) unsigned NOT NULL,
                     PRIMARY KEY (`id`),

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -107,6 +107,14 @@ class extension_Hashid_field extends Extension
                 );
             }
         }
+
+        if (version_compare($previousVersion, '2.0.0', '<=')) {
+            Symphony::Database()->query(
+                "ALTER TABLE `tbl_fields_hashid_field`
+                    DROP COLUMN `size`;"
+             );
+        }
+
     }
 
     public function uninstall()

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -19,6 +19,9 @@
     </authors>
 
     <releases>
+        <release version="2.0.1" date="2016-07-29" min="2.4" max="2.6.x">
+            - Fix and Removed size from Database
+        </release>
         <release version="2.0.0" date="2016-02-11" min="2.4" max="2.6.x">
             - Hash can now be up to 255 characters long
             - The hash value column in the database now enforces uniqueness

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -20,7 +20,7 @@
 
     <releases>
         <release version="2.0.1" date="2016-07-29" min="2.4" max="2.6.x">
-            - Fix and Removed size from Database
+            - Removed `size` from field table (#37)
         </release>
         <release version="2.0.0" date="2016-02-11" min="2.4" max="2.6.x">
             - Hash can now be up to 255 characters long

--- a/fields/field.hashid_field.php
+++ b/fields/field.hashid_field.php
@@ -127,7 +127,6 @@ class FieldHashid_field extends Field implements ExportableField
         $fields['field_id'] = $id;
         $fields['length'] = max(1, (int) $this->get('length'));
         $fields['salt'] = $this->get('salt');
-        $fields['size'] = max(1, (int) $this->get('size'));
 
         return FieldManager::saveSettings($id, $fields);
     }

--- a/fields/field.hashid_field.php
+++ b/fields/field.hashid_field.php
@@ -127,6 +127,7 @@ class FieldHashid_field extends Field implements ExportableField
         $fields['field_id'] = $id;
         $fields['length'] = max(1, (int) $this->get('length'));
         $fields['salt'] = $this->get('salt');
+        $fields['size'] = $this->get(1, (int) $this->get('size'));
 
         return FieldManager::saveSettings($id, $fields);
     }

--- a/fields/field.hashid_field.php
+++ b/fields/field.hashid_field.php
@@ -127,7 +127,7 @@ class FieldHashid_field extends Field implements ExportableField
         $fields['field_id'] = $id;
         $fields['length'] = max(1, (int) $this->get('length'));
         $fields['salt'] = $this->get('salt');
-        $fields['size'] = $this->get(1, (int) $this->get('size'));
+        $fields['size'] = max(1, (int) $this->get('size'));
 
         return FieldManager::saveSettings($id, $fields);
     }


### PR DESCRIPTION
Needed to add `$fields['size']` and a max()